### PR TITLE
fix to avoid click element overlapping

### DIFF
--- a/openquakeplatform_ipt/test/ipt_test.py
+++ b/openquakeplatform_ipt/test/ipt_test.py
@@ -18,6 +18,9 @@ class IptTest(unittest.TestCase):
             "' ex_gid ')]//button[@id='convertBtn' and @type='button'"
             " and normalize-space(text())='Convert to NRML']")
 
+        # required to avoiding wrong click on overlapping "About" link
+        convert_btn.location_once_scrolled_into_view
+
         convert_btn.click()
 
         pla.xpath_finduniq(


### PR DESCRIPTION
Backward compatible changes to run tests on selenium 3 - geckodriver test suite.
Test for current suite are green: https://ci.openquake.org/job/zdevel_oq-platform-standalone/46/
Test for new suite are green: https://ci.openquake.org/job/zdevel_oq-platform-standalone/45/