### PR TITLE
update possible exception for nrml.parse() method

### DIFF
--- a/openquakeplatform_ipt/views.py
+++ b/openquakeplatform_ipt/views.py
@@ -22,7 +22,7 @@ import tempfile
 import shutil
 from email.Utils import formatdate
 
-from lxml import etree
+from xml.parsers.expat import ExpatError
 from django.shortcuts import render_to_response
 from django.http import (HttpResponse,
                          HttpResponseBadRequest,
@@ -91,7 +91,7 @@ def validate_nrml(request):
     try:
         xml_text = xml_text.replace('\r\n', '\n').replace('\r', '\n')
         _do_validate_nrml(xml_text)
-    except etree.ParseError as exc:
+    except ExpatError as exc:
         return _make_response(error_msg=exc.message.message,
                               error_line=exc.message.lineno,
                               valid=False)


### PR DESCRIPTION
Removed lxml dependency updating nrml.parse() possible exception.
Tests are green: https://ci.openquake.org/job/zdevel_oq-platform-standalone/55