### PR TITLE
Moving from oq-engine as library to oq-engine as web-service

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ setup(
     author_email='devops@openquake.org',
     install_requires=[
         'django >=1.5, <1.11',
-        'openquake.engine',
-        'openquake.hazardlib',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
With this PR oq-platform is decoupled from the oq-engine code-base just interacting via http requests.
It is companion of oq-platform PR https://github.com/gem/oq-platform/pull/637.
Tests are green here: https://ci.openquake.org/job/zdevel_oq-platform/410/