### PR TITLE
Increase the number of significant digits on the rupture plane builder

### DIFF
--- a/openquakeplatform_ipt/build_rupture_plane.py
+++ b/openquakeplatform_ipt/build_rupture_plane.py
@@ -218,6 +218,6 @@ def get_rupture_surface_round(mag, hypocenter, strike, dip, rake):
     rupture_plane = get_rupture_surface(mag, hypocenter, strike, dip, rake)
     for corner in ["topLeft", "bottomLeft", "topRight", "bottomRight"]:
         for comp in ["lat", "lon", "depth"]:
-            rupture_plane[corner][comp] = "%.5g" % rupture_plane[corner][comp]
+            rupture_plane[corner][comp] = "%.5f" % rupture_plane[corner][comp]
 
     return rupture_plane


### PR DESCRIPTION
This PR changes the rounding of the rupture plane coordinates to five digits after the decimal point, rather than five digits altogether. This is critical for sites with ```longitude ≥ 100``` or ```longitude ≤ -100```, since the current rounding method leaves only two digits for such longitudes after the decimal point, which may lead to the following tolerance check failure with the engine:  ```raise ValueError("corner points do not lie on the same plane")```.