### PR TITLE
Little fix test upload 

### DIFF
--- a/openquakeplatform_ipt/test/examples_test.py
+++ b/openquakeplatform_ipt/test/examples_test.py
@@ -259,7 +259,7 @@ class IptUploadTest(unittest.TestCase):
         upload_file.submit()
 
         # wait for js upload callback to setup dropdown item properly
-        time.sleep(5)
+        time.sleep(8)
 
         list_files = Select(pla.xpath_finduniq(
             common + "//div[@name='rupture-file-html']"


### PR DESCRIPTION
Increased time sleep for test upload file in example_test
The tests are green here: https://ci.openquake.org/job/zdevel_oq-platform-standalone/228/