### PR TITLE
Make app compatible with Django 2.0+

### DIFF
--- a/openquakeplatform_ipt/urls.py
+++ b/openquakeplatform_ipt/urls.py
@@ -24,6 +24,7 @@ from openquakeplatform_ipt import views
 # from django.contrib import admin
 # admin.autodiscover()
 
+app_name = 'ipt'
 urlpatterns = [
     url(r'^(?P<tab_id>\d+)?$', views.view, name='home'),
     url(r'^upload/(?P<target>[^?]*)', views.upload, name='upload'),

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author='GEM Foundation',
     author_email='devops@openquake.org',
     install_requires=[
-        'django >=1.5, <1.11',
+        'django >=1.5, <2.1',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
Required by: https://github.com/gem/oq-engine/pull/3580

It's backward compatible.

https://ci.openquake.org/job/zdevel_oq-platform-standalone/234/