### PR TITLE
Exposure: separated csv files as default

### DIFF
--- a/openquakeplatform_ipt/__init__.py
+++ b/openquakeplatform_ipt/__init__.py
@@ -17,4 +17,4 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 header_info = {"title": "IPT"}
-__version__ = '1.13.0'
+__version__ = '1.14.0'

--- a/openquakeplatform_ipt/static/ipt/js/examples/1010.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/1010.js
@@ -1,5 +1,6 @@
 $(document).ready(function () {
-  $('.ex_gid #description').val('Example of exposure in Antioquia\nsimplest structural cost per building\nsingle MUR taxonomy');
+    $('.ex_gid input[name="exposure-type"][value="xml"]').prop('checked', true).triggerHandler('click');
+    $('.ex_gid #description').val('Example of exposure in Antioquia\nsimplest structural cost per building\nsingle MUR taxonomy');
     $('.ex_gid #costStruc').val('per_asset');
     $('.ex_gid #costStruc').trigger('change');
     { // blocks are used to reflect DOM hierarchy

--- a/openquakeplatform_ipt/static/ipt/js/examples/1940.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/1940.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    $('.ex_gid input[name="exposure-type"]').prop('checked', true).triggerHandler('click');
+    $('.ex_gid input[name="exposure-type"][value="csv"]').prop('checked', true).triggerHandler('click');
 
     $csv_files = ex_obj.o.find("div[name='exposure-csv-html'] select[name='file_html'] option")
     for (var i = 0 ; i < $csv_files.length ; i++) {

--- a/openquakeplatform_ipt/static/ipt/js/examples/1950.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/1950.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    $('.ex_gid input[name="exposure-type"]').prop('checked', true).triggerHandler('click');
+    $('.ex_gid input[name="exposure-type"][value="csv"]').prop('checked', true).triggerHandler('click');
 
     $csv_files = ex_obj.o.find("div[name='exposure-csv-html'] select[name='file_html'] option")
     for (var i = 0 ; i < $csv_files.length ; i++) {

--- a/openquakeplatform_ipt/static/ipt/js/examples/1960.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/1960.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    $('.ex_gid input[name="exposure-type"]').prop('checked', true).triggerHandler('click');
+    $('.ex_gid input[name="exposure-type"][value="csv"]').prop('checked', true).triggerHandler('click');
 
     $csv_files = ex_obj.o.find("div[name='exposure-csv-html'] select[name='file_html'] option")
     for (var i = 0 ; i < $csv_files.length ; i++) {

--- a/openquakeplatform_ipt/static/ipt/js/examples/1970.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/1970.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    $('.ex_gid input[name="exposure-type"]').prop('checked', true).triggerHandler('click');
+    $('.ex_gid input[name="exposure-type"][value="csv"]').prop('checked', true).triggerHandler('click');
 
     $csv_files = ex_obj.o.find("div[name='exposure-csv-html'] select[name='file_html'] option")
     for (var i = 0 ; i < $csv_files.length ; i++) {

--- a/openquakeplatform_ipt/static/ipt/js/examples/1980.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/1980.js
@@ -1,4 +1,6 @@
 $(document).ready(function () {
+    $('.ex_gid input[name="exposure-type"][value="xml"]').prop('checked', true).triggerHandler('click');
+
     $('.ex_gid #description').val('The description of exposure function');
     $('.ex_gid #costStruc').val('per_asset');
     $('.ex_gid #costStruc').trigger('change');

--- a/openquakeplatform_ipt/static/ipt/js/examples/1990.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/1990.js
@@ -1,4 +1,6 @@
 $(document).ready(function () {
+    $('.ex_gid input[name="exposure-type"][value="xml"]').prop('checked', true).triggerHandler('click');
+
     $('.ex_gid #description').val('The description of exposure function');
     $('.ex_gid #costStruc').val('per_asset');
     $('.ex_gid #costStruc').trigger('change');

--- a/openquakeplatform_ipt/templates/ipt/tabs/exposure.html
+++ b/openquakeplatform_ipt/templates/ipt/tabs/exposure.html
@@ -102,12 +102,12 @@
       <div class="menuItems" style="text-align: center;">
         <form style="margin: 0px;">
           <div class="chbox">
-            <input style="margin:0;" type="radio" name="exposure-type" value="xml" checked>
-            <span class="inlible">XML Exposure (all in one file)</span>
+            <input style="margin:0;" type="radio" name="exposure-type" value="csv" checked>
+            <span class="inlible">CSV Exposure (one XML plus one or more CSV files)</span>
           </div>
           <div class="chbox chbox_last">
-            <input style="margin:0;" type="radio" name="exposure-type" value="csv">
-            <span class="inlible">CSV Exposure (one XML plus one or more CSV files)</span>
+            <input style="margin:0;" type="radio" name="exposure-type" value="xml">
+            <span class="inlible">XML Exposure (all in one file)</span>
           </div>
         </form>
       </div>

--- a/openquakeplatform_ipt/test/ipt_test.py
+++ b/openquakeplatform_ipt/test/ipt_test.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import unittest
-from openquake.moon import platform_get
+from openquake.moon import platform_get, TimeoutError
 from selenium.webdriver.common.keys import Keys
+import time
 
 
 class IptTest(unittest.TestCase):
@@ -14,6 +15,21 @@ class IptTest(unittest.TestCase):
 
         # <button id="saveBtnEX" type="button" style="display: block;"
         #     class="btn btn-primary">Convert to NRML</button>
+        try:
+            footer = pla.xpath_finduniq("//footer")
+
+            # hide footer
+            pla.driver.execute_script(
+                "$(arguments[0]).attr('style','display:none;')", footer)
+        except TimeoutError:
+            pass
+
+        xml_radio_type = pla.xpath_finduniq(
+            "//div[@name = 'exposure-type']"
+            "//input[@type = 'radio' and @value = 'xml']")
+        xml_radio_type.click()
+
+        time.sleep(2)
 
         convert_btn = pla.xpath_finduniq(
             "//div[contains(concat(' ',normalize-space(@class),' '),"
@@ -35,11 +51,21 @@ class IptTest(unittest.TestCase):
         pla = platform_get()
         pla.get('/ipt')
 
-        footer = pla.xpath_finduniq("//footer")
+        try:
+            footer = pla.xpath_finduniq("//footer")
 
-        # hide footer
-        pla.driver.execute_script(
-            "$(arguments[0]).attr('style','display:none;')", footer)
+            # hide footer
+            pla.driver.execute_script(
+                "$(arguments[0]).attr('style','display:none;')", footer)
+        except TimeoutError:
+            pass
+
+        xml_radio_type = pla.xpath_finduniq(
+            "//div[@name = 'exposure-type']"
+            "//input[@type = 'radio' and @value = 'xml']")
+        xml_radio_type.click()
+
+        time.sleep(2)
 
         # Check add rows for exposure table
         new_row_btn = pla.xpath_finduniq(
@@ -63,7 +89,6 @@ class IptTest(unittest.TestCase):
         # Click add row and check if exists new rows
         for id_tbl in range(1, 2):
             new_table_btn.click()
-            print('id table: %s' % id_tbl)
             new_table_btn = pla.xpath_finduniq(
                 "//div[@name='exposuretbl-%s']" % id_tbl)
 


### PR DESCRIPTION
With this PR we set separated csv file as exposure type default.
Tests are green:
  * https://ci.openquake.org/job/zdevel_oq-platform2/988/
  * https://ci.openquake.org/job/zdevel_oq-platform-standalone/298/