### PR TITLE
Exposure header description.

### DIFF
--- a/openquakeplatform_ipt/__init__.py
+++ b/openquakeplatform_ipt/__init__.py
@@ -17,4 +17,4 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 header_info = {"title": "IPT"}
-__version__ = '1.15.7'
+__version__ = '1.15.8'

--- a/openquakeplatform_ipt/static/ipt/css/ipt.css
+++ b/openquakeplatform_ipt/static/ipt/css/ipt.css
@@ -267,3 +267,16 @@ ul.phen-list li {
     list-style-position: inside;
     padding-left: 8px;
 }
+
+table.tbl-exam-exposure {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0 16px 0;
+}
+
+table.tbl-exam-exposure th {
+    padding: 4px;
+    text-align: center;
+    border: 1px solid #ccc;
+    background-color: #fafafa;
+}

--- a/openquakeplatform_ipt/static/ipt/js/exposure.js
+++ b/openquakeplatform_ipt/static/ipt/js/exposure.js
@@ -620,6 +620,14 @@ function ex_updateTable() {
     }
     ex_obj.o.find('#outputText').empty();
     ex_obj.o.find('#convertBtn').show();
+
+    var $tr_exam_exp = $('<tr>');
+    for (var i = 0 ; i < ex_obj.header.length ; i++) {
+        $tr_exam_exp.append($('<th>').text(ex_obj.header[i]));
+    }
+    var $tbl_exam_exp = ex_obj.o.find('table.tbl-exam-exposure');
+    $tbl_exam_exp.empty();
+    $tbl_exam_exp.append($tr_exam_exp);
 }
 
 ex_obj.o.find('#downloadBtn').click(function() {

--- a/openquakeplatform_ipt/templates/ipt/tabs/exposure.html
+++ b/openquakeplatform_ipt/templates/ipt/tabs/exposure.html
@@ -114,13 +114,17 @@
     </div>
 
     <div name="exposuretbl-descr" class="alert alert-info exposure-type-xml" role="alert">2. Copy and paste values from a spreadsheet into the table below OR upload a CSV file with the same columns number.</div>
-    <div name="exposuretbl" class="exposure-type-xml">
+    <div name="exposuretbl" class="exposure-type-xml" style="display: none;">
       <div name="exposuretbls">
       </div>
       <button id="new_exposuretbl_add" type="button" class="btn btn-primary">Add New Table</button>
     </div>
 
-    <div class="exposure-type-csv"  style="display: none;">
+    <div class="exposure-type-csv">
+      <div class="menuItems">
+        <label>CSV Header Description</label>
+        <table class="tbl-exam-exposure"></table>
+      </div>
       <div class="menuItems" name="exposure-csv-html">
         <label>Exposure CSV file[s] <span class="ui-icon ui-icon-help ipt_help" title='FIXME.'></span></a>
           :</label>


### PR DESCRIPTION
Add a dynamic description of a valid CSV header.
Tests are green here:
  * https://ci.openquake.org/job/zdevel_oq-platform2/1048/
  * https://ci.openquake.org/job/zdevel_oq-platform-standalone/324/

## Example:
![pro-header](https://user-images.githubusercontent.com/1670278/66290845-97e20080-e8e0-11e9-9e87-6179db3e544a.png)
