### PR TITLE
refactoring checkboxes that doesn't imply form changes

### DIFF
--- a/openquakeplatform_ipt/static/ipt/css/ipt.css
+++ b/openquakeplatform_ipt/static/ipt/css/ipt.css
@@ -289,3 +289,12 @@ table.imt-levels {
 table.imt-levels td input {
     width: 100%;
 }
+
+.cbox-leaf {
+    padding: 3px;
+    border: 1px solid #ccc;
+    width: 80px;
+    display: inline-block;
+    text-align: center;
+    border-radius: 3px;
+}

--- a/openquakeplatform_ipt/static/ipt/js/exposure.js
+++ b/openquakeplatform_ipt/static/ipt/js/exposure.js
@@ -564,7 +564,7 @@ function ex_updateTable() {
     ex_obj.headerbase_len = ex_obj.header.length;
 
     // manage tags
-    ex_obj.header_exam = ex_obj.header.concat([])
+    ex_obj.header_exam = ex_obj.header.concat([]);
     var tags = ex_obj.o.find('#tags').tagsinput('items');
     for (var i = 0 ; i < tags.length ; i++) {
         ex_obj.header.push("tag_" + tags[i]);

--- a/openquakeplatform_ipt/templates/ipt/ipt.js
+++ b/openquakeplatform_ipt/templates/ipt/ipt.js
@@ -51,24 +51,4 @@ for (var i = 0 ; i < g_gmpe.length ; i++) {
         console.log(gem_api);
 {% endif %}
     }
-
-    $(document).ready(function () {
-        function bbox_leaf_cb(ev)
-        {
-            var $target = $(ev.target);
-            var $parent = $target.parent();
-
-            if ($target.is(':checked')) {
-                $parent.css('background-color', '#d9f7d9');
-                $parent.css('border-color', '#76f176');
-            }
-            else {
-                $parent.css('background-color', '');
-                $parent.css('border-color', '');
-            }
-        }
-
-        $('input.cbox-leaf[type="checkbox"]').click(bbox_leaf_cb);
-        $('input.cbox-leaf[type="checkbox"]').map(function() { bbox_leaf_cb({target: this});});
-    });
 }

--- a/openquakeplatform_ipt/templates/ipt/ipt.js
+++ b/openquakeplatform_ipt/templates/ipt/ipt.js
@@ -51,4 +51,24 @@ for (var i = 0 ; i < g_gmpe.length ; i++) {
         console.log(gem_api);
 {% endif %}
     }
+
+    $(document).ready(function () {
+        function bbox_leaf_cb(ev)
+        {
+            var $target = $(ev.target);
+            var $parent = $target.parent();
+
+            if ($target.is(':checked')) {
+                $parent.css('background-color', '#d9f7d9');
+                $parent.css('border-color', '#76f176');
+            }
+            else {
+                $parent.css('background-color', '');
+                $parent.css('border-color', '');
+            }
+        }
+
+        $('input.cbox-leaf[type="checkbox"]').click(bbox_leaf_cb);
+        $('input.cbox-leaf[type="checkbox"]').map(function() { bbox_leaf_cb({target: this});});
+    });
 }

--- a/openquakeplatform_ipt/templates/ipt/tabs/cf/event_based.html
+++ b/openquakeplatform_ipt/templates/ipt/tabs/cf/event_based.html
@@ -180,7 +180,7 @@
     <input type="text" name="ret_periods_for_aggr"
            placeholder="5, 10, 25, 50, 100, 250, 500, 1000"
            title="Comma-separated list of values for the return periods at which the loss exceedance curves will be evaluated. If this parameter is left blank, the OpenQuake-engine will evaluate the loss exceedance curves at a set of default return periods."
-           style="width: 600px";>
+           style="width: 600px;">
   </div>
 </div>
 
@@ -189,67 +189,57 @@
 
   <div name="hazard-outputs">
     <div class="menuItems">
-      <table class="field">
-        <tr><td class="cbox">
-            <input style="vertical-align: top;" type="checkbox" name="ground_motion_fields" checked="checked">
-          </td><td>
-            <label>Ground motion fields</label>
-        </td></tr>
-      </table>
+      <label>Ground motion fields</label>
+      <div class="cbox-leaf">
+        <input class="cbox-leaf" style="vertical-align: top;" type="checkbox" name="ground_motion_fields" checked="checked">
+      </div>
     </div>
 
-    <div class="menuItems">
-      <table class="field">
-        <tr><td class="cbox">
-            <input style="vertical-align: top;" type="checkbox" name="hazard_curves_from_gmfs">
-          </td><td>
-            <label>Hazard curves <span style="font-weight: bold; color: #d9edf7;">(♦)</span></label>
-        </td></tr>
-      </table>
+    <div class="alert alert-info ipt-info" role="alert">
+      <div style="text-align: center;">
+        <div class="chbox">
+          <input type="checkbox" name="hazard_curves_from_gmfs">
+          <span class="inlible">Add hazard curves</span>
+        </div>
+      </div>
     </div>
 
     <div name="hazard-curves">
-      <div class="menuItems">
-        <table class="field">
-          <tr><td class="cbox">
-              <input style="vertical-align: top;" type="checkbox" name="hazard_maps">
-            </td><td>
-              <label>Hazard maps <span style="font-weight: bold; color: #d9edf7;">(♦)</span></label>
-          </td></tr>
-        </table>
+      <div class="alert alert-info ipt-info" role="alert">
+        <div style="text-align: center;">
+          <div class="chbox">
+            <input type="checkbox" name="hazard_maps">
+            <span class="inlible">Add hazard maps</span>
+          </div>
+        </div>
       </div>
 
       <div class="menuItems" name="poes">
         <label>List of probability of exceedances:</label><br>
         <input type="text" name="poes"
-               value="0.02, 0.10" style="width: 600px";>
+               value="0.02, 0.10" style="width: 600px;">
       </div>
 
       <div class="menuItems" name="uniform-hazard-spectra">
-        <table class="field">
-          <tr><td class="cbox">
-              <input style="vertical-align: top;" type="checkbox" name="uniform_hazard_spectra">
-            </td><td>
-              <label>Uniform hazard spectra</label>
-          </td></tr>
-        </table>
+        <label>Uniform hazard spectra</label>
+        <div class="cbox-leaf">
+          <input type="checkbox" class="cbox-leaf" style="vertical-align: top;" name="uniform_hazard_spectra">
+        </div>
       </div>
     </div> <!-- hazard-curves -->
   </div> <!-- hazard-outputs -->
   <div class="alert alert-info ipt-info" role="alert" name="risk-outputs-group">
     <div style="text-align: center;">
-      <form style="margin: 0px;">
-        <div class="chbox">
-          <input type="checkbox" name="conditional_loss_poes_choice">
-          <span class="inlible">Include loss maps</span>
-        </div>
-      </form>
+      <div class="chbox">
+        <input type="checkbox" name="conditional_loss_poes_choice">
+        <span class="inlible">Include loss maps</span>
+      </div>
     </div>
   </div>
   <div class="menuItems" name="conditional-loss-poes">
     <label>Loss maps:</label><br>
     <input type="text" name="conditional_loss_poes"
-           value="0.02, 0.10" style="width: 600px";>
+           value="0.02, 0.10" style="width: 600px;">
   </div>
 
   <div class="menuItems" name="quantiles" style="margin-top: 8px;">
@@ -257,16 +247,13 @@
     <input type="text" name="quantiles"
            placeholder="optional comma separated list of floats > 0.0"
            title="List of quantiles to compute the curves (separated by comma)"
-           style="width: 600px";>
+           style="width: 600px;">
   </div>
   <div class="menuItems">
-    <table class="field">
-      <tr><td class="cbox">
-          <input style="vertical-align: top;" type="checkbox" name="individual-curves" checked="checked">
-        </td><td>
-          <label>Curves per realization <span class="ui-icon ui-icon-help ipt_help" title='Include in the calculation outputs the curves per realization'></span></label>
-      </td></tr>
-    </table>
+    <label style="vertical-align: bottom;">Curves per realization <span class="ui-icon ui-icon-help ipt_help" title='Include in the calculation outputs the curves per realization'></span></label>
+    <div class="cbox-leaf">
+      <input type="checkbox" class="cbox-leaf" style="vertical-align: top;" name="individual-curves" checked="checked">
+    </div>
   </div>
 </div>
 

--- a/openquakeplatform_ipt/templates/ipt/tabs/cf/event_based.html
+++ b/openquakeplatform_ipt/templates/ipt/tabs/cf/event_based.html
@@ -245,7 +245,7 @@
   <div class="menuItems" name="quantiles" style="margin-top: 8px;">
     <label>Quantiles  <span class="ui-icon ui-icon-help ipt_help" title='List of quantiles to compute the curves (separated by comma)'></span>:</label>
     <input type="text" name="quantiles"
-           placeholder="optional comma separated list of floats > 0.0"
+           placeholder="Optional. List of values in the range (0.0, 1.0). For example: 0.15, 0.85"
            title="List of quantiles to compute the curves (separated by comma)"
            style="width: 600px;">
   </div>


### PR DESCRIPTION
With this PR we fix behavior inconsistency of checkboxes for ``Hazard output`` config file section.
A new style for checkboxes that doesn't imply form changes is added.

Tests are running here:
  * https://ci.openquake.org/job/zdevel_oq-platform2/1068/
  * https://ci.openquake.org/job/zdevel_oq-platform-standalone/341/

![new-cbox](https://user-images.githubusercontent.com/1670278/67295963-1eedc600-f4e8-11e9-933c-e4d75d072a54.gif)
