### PR TITLE
set examples folder separator accordingly with server SO file system

### DIFF
--- a/openquakeplatform_ipt/static/ipt/js/examples/6903.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6903.js
@@ -22,13 +22,13 @@ $(document).ready(function () {
         $(cf_obj['e_b'].pfx + ' div[name="exposure-model"] input[type="checkbox"][name="taxonomy-mapping-choice"]'
          ).prop('checked', true).triggerHandler('click');
 
-        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model/vulnerability_model_BOG.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file/source_model_logic_tree.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file/int_col_bog.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file/gmpe_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model' + gem_path_sep + 'vulnerability_model_BOG.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file' + gem_path_sep + 'source_model_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file' + gem_path_sep + 'int_col_bog.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file' + gem_path_sep + 'gmpe_logic_tree.xml');
 
-        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model/vulnerability_model_BOG.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model' + gem_path_sep + 'vulnerability_model_BOG.xml');
 
         $(cf_obj['e_b'].pfx + ' div[name="exposure-model"] div[name="taxonomy-mapping"] select[name="file_html"]').val(
             'taxonomy_mapping/tax-map-good.csv');

--- a/openquakeplatform_ipt/static/ipt/js/examples/6944.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6944.js
@@ -14,11 +14,11 @@ $(document).ready(function () {
 
 
     setTimeout(function () {
-        $(cf_obj['vol'].pfx + ' div[name="ashfall-file-html"] select[name="file_html"]').val('ashfall_file/ashfall_geom.zip');
+        $(cf_obj['vol'].pfx + ' div[name="ashfall-file-html"] select[name="file_html"]').val('ashfall_file' + gem_path_sep + 'ashfall_geom.zip');
         $(cf_obj['vol'].pfx + ' div[name="ashfall-file-html"] select[name="file_html"]').triggerHandler('change');
-        $(cf_obj['vol'].pfx + ' div[name="lavaflow-file-html"] select[name="file_html"]').val('lavaflow_file/lavaflow_vol_full.csv');
-        $(cf_obj['vol'].pfx + ' div[name="lahar-file-html"] select[name="file_html"]').val('lahar_file/lahar_vol_full.csv');
-        $(cf_obj['vol'].pfx + ' div[name="pyroclasticflow-file-html"] select[name="file_html"]').val('pyroclasticflow_file/pyroclasticflow_vol_full.csv');
+        $(cf_obj['vol'].pfx + ' div[name="lavaflow-file-html"] select[name="file_html"]').val('lavaflow_file' + gem_path_sep + 'lavaflow_vol_full.csv');
+        $(cf_obj['vol'].pfx + ' div[name="lahar-file-html"] select[name="file_html"]').val('lahar_file' + gem_path_sep + 'lahar_vol_full.csv');
+        $(cf_obj['vol'].pfx + ' div[name="pyroclasticflow-file-html"] select[name="file_html"]').val('pyroclasticflow_file' + gem_path_sep + 'pyroclasticflow_vol_full.csv');
         
         $(cf_obj['vol'].pfx + '  div[name="ashfall-input"] input[type="text"][name="spec-ass-haz-dist"]').val(10.0)
         $(cf_obj['vol'].pfx + '  div[name="lavaflow-input"] input[type="text"][name="spec-ass-haz-dist"]').val(12.0)
@@ -26,12 +26,12 @@ $(document).ready(function () {
         $(cf_obj['vol'].pfx + '  div[name="pyroclasticflow-input"] input[type="text"][name="spec-ass-haz-dist"]').val(16.0)
         
         
-        $(cf_obj['vol'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model_vol_full.zip');
+        $(cf_obj['vol'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model_vol_full.zip');
 
-        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-file-html"] select[name="file_html"]').val('fragility_model/fragility_model_vol_full.xml');
+        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-file-html"] select[name="file_html"]').val('fragility_model' + gem_path_sep + 'fragility_model_vol_full.xml');
 
         $(cf_obj['vol'].pfx + ' input[type="checkbox"][name="is-cons-models"]').prop('checked', true).triggerHandler('click');
-        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-cons-html"] select[name="file_html"]').val('fragility_cons/consequence_model_vol_full.xml');
+        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-cons-html"] select[name="file_html"]').val('fragility_cons' + gem_path_sep + 'consequence_model_vol_full.xml');
 
         // Click to download EventBase.zip
         setTimeout(function () {

--- a/openquakeplatform_ipt/static/ipt/js/examples/6954.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6954.js
@@ -10,15 +10,15 @@ $(document).ready(function () {
 
 
     setTimeout(function () {
-        $(cf_obj['vol'].pfx + ' div[name="lavaflow-file-html"] select[name="file_html"]').val('lavaflow_file/lava-geom-shp.zip');
-        $(cf_obj['vol'].pfx + ' div[name="lahar-file-html"] select[name="file_html"]').val('lahar_file/lahar-geom.zip');
+        $(cf_obj['vol'].pfx + ' div[name="lavaflow-file-html"] select[name="file_html"]').val('lavaflow_file' + gem_path_sep + 'lava-geom-shp.zip');
+        $(cf_obj['vol'].pfx + ' div[name="lahar-file-html"] select[name="file_html"]').val('lahar_file' + gem_path_sep + 'lahar-geom.zip');
 
-        $(cf_obj['vol'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model_vol_full.zip');
+        $(cf_obj['vol'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model_vol_full.zip');
 
-        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-file-html"] select[name="file_html"]').val('fragility_model/fragility_model_vol_full.xml');
+        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-file-html"] select[name="file_html"]').val('fragility_model' + gem_path_sep + 'fragility_model_vol_full.xml');
 
         $(cf_obj['vol'].pfx + ' input[type="checkbox"][name="is-cons-models"]').prop('checked', true).triggerHandler('click');
-        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-cons-html"] select[name="file_html"]').val('fragility_cons/consequence_model_vol_full.xml');
+        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-cons-html"] select[name="file_html"]').val('fragility_cons' + gem_path_sep + 'consequence_model_vol_full.xml');
 
         // Click to download EventBase.zip
         setTimeout(function () {

--- a/openquakeplatform_ipt/static/ipt/js/examples/6960.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6960.js
@@ -1,16 +1,16 @@
 $(document).ready(function () {
     $('a[href="#subtabs-3"]').click();
-    $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model.xml');
+    $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model.xml');
     $(cf_obj['e_b'].pfx + ' div[name="vulnerability-model"] input[type="checkbox"][name="losstype"][value="occupants"]').prop('checked', true).triggerHandler('click');
 
-    $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model/modelo_vulnerabilidad_estructural.xml');
-    $(cf_obj['e_b'].pfx + ' div[name="vm-occupants-html"] select[name="file_html"]').val('vulnerability_model/modelo_vulnerabilidad_ocupantes.xml');
+    $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model' + gem_path_sep + 'modelo_vulnerabilidad_estructural.xml');
+    $(cf_obj['e_b'].pfx + ' div[name="vm-occupants-html"] select[name="file_html"]').val('vulnerability_model' + gem_path_sep + 'modelo_vulnerabilidad_ocupantes.xml');
 
-    $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val("source_model_logic_tree_file/source_model_logic_tree.xml");
+    $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val("source_model_logic_tree_file' + gem_path_sep + 'source_model_logic_tree.xml");
 
-    $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val("source_model_file/source_model_Antioquia_200km.xml");
+    $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val("source_model_file' + gem_path_sep + 'source_model_Antioquia_200km.xml");
 
-    $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val("gsim_logic_tree_file/gmpe_logic_tree_col2016_redux.xml");
+    $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val("gsim_logic_tree_file' + gem_path_sep + 'gmpe_logic_tree_col2016_redux.xml");
     
 
 
@@ -19,7 +19,7 @@ $(document).ready(function () {
 
     $(cf_obj['e_b'].pfx + ' div[name="site-conditions"] input[type="radio"][name="hazard_sitecond"][value="from-file"]').prop('checked', true).triggerHandler('click');
 
-    $(cf_obj['e_b'].pfx + ' div[name="hazard-sitecond_from-file"] select[name="file_html"]').val('site_conditions/site_model_surrogate.xml');
+    $(cf_obj['e_b'].pfx + ' div[name="hazard-sitecond_from-file"] select[name="file_html"]').val('site_conditions' + gem_path_sep + 'site_model_surrogate.xml');
 
     // $(cf_obj['e_b'].pfx + ' button[name="download"]').click();
     window.gem_example_completed = true;

--- a/openquakeplatform_ipt/static/ipt/js/examples/6961.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6961.js
@@ -54,9 +54,9 @@ $(document).ready(function () {
             'fragility_cons/businter_consequence_model.xml');
 
 
-        $(cf_obj['scen'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model_vol_full.zip');
+        $(cf_obj['scen'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model_vol_full.zip');
 
-        $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('rupture_file/earthquake_rupture_model.xml');
+        $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('rupture_file' + gem_path_sep + 'earthquake_rupture_model.xml');
         // waiting for gmpe list population
         $(cf_obj['scen'].pfx + ' div[name="hazard-gmpe_specify-gmpe"] div.sol-label-text:contains("AbrahamsonEtAl2014RegCHN")'
          ).click()

--- a/openquakeplatform_ipt/static/ipt/js/examples/6963.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6963.js
@@ -18,11 +18,11 @@ $(document).ready(function () {
     table.loadData(data);
 
     setTimeout(function () {
-        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model/vulnerability_model_BOG.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file/source_model_logic_tree.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file/int_col_bog.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file/gmpe_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model' + gem_path_sep + 'vulnerability_model_BOG.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file' + gem_path_sep + 'source_model_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file' + gem_path_sep + 'int_col_bog.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file' + gem_path_sep + 'gmpe_logic_tree.xml');
 
         // Click check rupture mesh spacing and area source discretization
         $(cf_obj['e_b'].pfx + ' input[type="checkbox"][name="rupture_mesh_spacing_choice"]').prop('checked', true).triggerHandler('click');

--- a/openquakeplatform_ipt/static/ipt/js/examples/6971.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6971.js
@@ -30,9 +30,9 @@ $(document).ready(function () {
 
     setTimeout(function () {
 
-        $(cf_obj['scen'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model_vol_full.zip');
+        $(cf_obj['scen'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model_vol_full.zip');
 
-        $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('rupture_file/earthquake_rupture_model.xml');
+        $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('rupture_file' + gem_path_sep + 'earthquake_rupture_model.xml');
         // waiting for gmpe list population
         $(cf_obj['scen'].pfx + ' div[name="hazard-gmpe_specify-gmpe"] div.sol-label-text:contains("AbrahamsonEtAl2014RegCHN")'
          ).click()

--- a/openquakeplatform_ipt/static/ipt/js/examples/6973.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6973.js
@@ -20,11 +20,11 @@ $(document).ready(function () {
     setTimeout(function () {
         $(cf_obj['e_b'].pfx + ' div[name="risk-outputs"] input[type="checkbox"][name="individual-curves"]').prop('checked', false).triggerHandler('click');
 
-        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model/vulnerability_model_BOG.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file/source_model_logic_tree.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file/int_col_bog.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file/gmpe_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model' + gem_path_sep + 'vulnerability_model_BOG.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file' + gem_path_sep + 'source_model_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file' + gem_path_sep + 'int_col_bog.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file' + gem_path_sep + 'gmpe_logic_tree.xml');
 
         // Click check rupture mesh spacing and area source discretization
         $(cf_obj['e_b'].pfx + ' input[type="checkbox"][name="rupture_mesh_spacing_choice"]').prop('checked', true).triggerHandler('click');

--- a/openquakeplatform_ipt/static/ipt/js/examples/6980.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6980.js
@@ -2,7 +2,7 @@ $(document).ready(function () {
     // this is a workaround for a bug fixed in jquery 1.9 (checked is toggled after that handler is fired
     $(cf_obj['scen'].pfx + ' input[type="checkbox"][name="hazard"]').prop('checked', true).triggerHandler('click');
     $(cf_obj['scen'].pfx + ' input[type="checkbox"][name="risk"]').prop('checked', true).triggerHandler('click');
-    $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('data/rupture_file/rupture_new.xml');
+    $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('data/rupture_file' + gem_path_sep + 'rupture_new.xml');
 
     var data = [ [ "40", "40" ], ["30", "30"], ["20", "20" ] ];
 
@@ -10,11 +10,11 @@ $(document).ready(function () {
     table.loadData(data);
 
     /* exposure model */
-    $(cf_obj['scen'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('data/exposure_model/exposure_model.xml');
+    $(cf_obj['scen'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('data/exposure_model' + gem_path_sep + 'exposure_model.xml');
     $(cf_obj['scen'].pfx + ' div[name="exposure-model"] input[type="checkbox"][name="include"]').prop('checked', true).triggerHandler('click');
 
     $(cf_obj['scen'].pfx + ' div[name="fragility-model"] div[name="fm-loss-'
-                            + "structural" + '"] select[name="file_html"]').val('data/fragility_model/pippo.xml');
+                            + "structural" + '"] select[name="file_html"]').val('data/fragility_model' + gem_path_sep + 'pippo.xml');
 
     $(cf_obj['scen'].pfx + ' div[name="hazard-gmpe_specify-gmpe"] input[type="text"]').focus();
     setTimeout(function () {

--- a/openquakeplatform_ipt/static/ipt/js/examples/6981.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6981.js
@@ -19,9 +19,9 @@ $(document).ready(function () {
     
     $(cf_obj['scen'].pfx + ' div[name="hazard-gmpe_specify-gmpe"] input[type="text"]').focus();
     setTimeout(function () {
-        $(cf_obj['scen'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model_vol_full.zip');
+        $(cf_obj['scen'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model_vol_full.zip');
         
-        $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('rupture_file/earthquake_rupture_model.xml');
+        $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('rupture_file' + gem_path_sep + 'earthquake_rupture_model.xml');
         // waiting for gmpe list population
         $(cf_obj['scen'].pfx + ' div[name="hazard-gmpe_specify-gmpe"] div.sol-label-text:contains("AbrahamsonEtAl2014RegCHN")'
          ).click()

--- a/openquakeplatform_ipt/static/ipt/js/examples/6983.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6983.js
@@ -20,11 +20,11 @@ $(document).ready(function () {
     table.loadData(data);
 
     setTimeout(function () {
-        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model/vulnerability_model_BOG.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file/source_model_logic_tree.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file/int_col_bog.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file/gmpe_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model' + gem_path_sep + 'vulnerability_model_BOG.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file' + gem_path_sep + 'source_model_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file' + gem_path_sep + 'int_col_bog.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file' + gem_path_sep + 'gmpe_logic_tree.xml');
 
         // Click check rupture mesh spacing and area source discretization
         $(cf_obj['e_b'].pfx + ' input[type="checkbox"][name="rupture_mesh_spacing_choice"]').prop('checked', true).triggerHandler('click');

--- a/openquakeplatform_ipt/static/ipt/js/examples/6991.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6991.js
@@ -16,7 +16,7 @@ $(document).ready(function () {
     
     $(cf_obj['scen'].pfx + ' div[name="hazard-gmpe_specify-gmpe"] input[type="text"]').focus();
     setTimeout(function () {
-        $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('rupture_file/earthquake_rupture_model.xml');
+        $(cf_obj['scen'].pfx + ' div[name="rupture-file-html"] select[name="file_html"]').val('rupture_file' + gem_path_sep + 'earthquake_rupture_model.xml');
         // waiting for gmpe list population
         $(cf_obj['scen'].pfx + ' div[name="hazard-gmpe_specify-gmpe"] div.sol-label-text:contains("AbrahamsonEtAl2014RegCHN")'
          ).click()

--- a/openquakeplatform_ipt/static/ipt/js/examples/6993.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6993.js
@@ -17,11 +17,11 @@ $(document).ready(function () {
     table.loadData(data);
 
     setTimeout(function () {
-        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model/vulnerability_model_BOG.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file/source_model_logic_tree.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file/int_col_bog.xml');
-        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file/gmpe_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="vm-structural-html"] select[name="file_html"]').val('vulnerability_model' + gem_path_sep + 'vulnerability_model_BOG.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-logic-tree-file-html"] select[name="file_html"]').val('source_model_logic_tree_file' + gem_path_sep + 'source_model_logic_tree.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="source-model-file-html"] select[name="file_html"]').val('source_model_file' + gem_path_sep + 'int_col_bog.xml');
+        $(cf_obj['e_b'].pfx + ' div[name="gsim-logic-tree-file-html"] select[name="file_html"]').val('gsim_logic_tree_file' + gem_path_sep + 'gmpe_logic_tree.xml');
 
         // Click check rupture mesh spacing and area source discretization
         $(cf_obj['e_b'].pfx + ' input[type="checkbox"][name="rupture_mesh_spacing_choice"]').prop('checked', true).triggerHandler('click');

--- a/openquakeplatform_ipt/static/ipt/js/examples/6994.js
+++ b/openquakeplatform_ipt/static/ipt/js/examples/6994.js
@@ -14,10 +14,10 @@ $(document).ready(function () {
 
 
     setTimeout(function () {
-        $(cf_obj['vol'].pfx + ' div[name="ashfall-file-html"] select[name="file_html"]').val('ashfall_file/ashfall_vol_full.csv');
-        $(cf_obj['vol'].pfx + ' div[name="lavaflow-file-html"] select[name="file_html"]').val('lavaflow_file/lavaflow_vol_full.csv');
-        $(cf_obj['vol'].pfx + ' div[name="lahar-file-html"] select[name="file_html"]').val('lahar_file/lahar_vol_full.csv');
-        $(cf_obj['vol'].pfx + ' div[name="pyroclasticflow-file-html"] select[name="file_html"]').val('pyroclasticflow_file/pyroclasticflow_vol_full.csv');
+        $(cf_obj['vol'].pfx + ' div[name="ashfall-file-html"] select[name="file_html"]').val('ashfall_file' + gem_path_sep + 'ashfall_vol_full.csv');
+        $(cf_obj['vol'].pfx + ' div[name="lavaflow-file-html"] select[name="file_html"]').val('lavaflow_file' + gem_path_sep + 'lavaflow_vol_full.csv');
+        $(cf_obj['vol'].pfx + ' div[name="lahar-file-html"] select[name="file_html"]').val('lahar_file' + gem_path_sep + 'lahar_vol_full.csv');
+        $(cf_obj['vol'].pfx + ' div[name="pyroclasticflow-file-html"] select[name="file_html"]').val('pyroclasticflow_file' + gem_path_sep + 'pyroclasticflow_vol_full.csv');
         
         $(cf_obj['vol'].pfx + '  div[name="ashfall-input"] input[type="text"][name="spec-ass-haz-dist"]').val(10.0)
         $(cf_obj['vol'].pfx + '  div[name="lavaflow-input"] input[type="text"][name="spec-ass-haz-dist"]').val(12.0)
@@ -25,12 +25,12 @@ $(document).ready(function () {
         $(cf_obj['vol'].pfx + '  div[name="pyroclasticflow-input"] input[type="text"][name="spec-ass-haz-dist"]').val(16.0)
         
         
-        $(cf_obj['vol'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model/exposure_model_vol_full.zip');
+        $(cf_obj['vol'].pfx + ' div[name="exposure-model-html"] select[name="file_html"]').val('exposure_model' + gem_path_sep + 'exposure_model_vol_full.zip');
 
-        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-file-html"] select[name="file_html"]').val('fragility_model/fragility_model_vol_full.xml');
+        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-file-html"] select[name="file_html"]').val('fragility_model' + gem_path_sep + 'fragility_model_vol_full.xml');
 
         $(cf_obj['vol'].pfx + ' input[type="checkbox"][name="is-cons-models"]').prop('checked', true).triggerHandler('click');
-        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-cons-html"] select[name="file_html"]').val('fragility_cons/consequence_model_vol_full.xml');
+        $(cf_obj['vol'].pfx + ' div[name="fm-ashfall-cons-html"] select[name="file_html"]').val('fragility_cons' + gem_path_sep + 'consequence_model_vol_full.xml');
 
         // Click to download EventBase.zip
         setTimeout(function () {

--- a/openquakeplatform_ipt/templates/ipt/ipt.html
+++ b/openquakeplatform_ipt/templates/ipt/ipt.html
@@ -127,6 +127,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/agpl.html>.
     </script>
     {% with subtab_semi=request.GET.subtab_id|default:0 %}
         {% if request.GET.example_id|add:"0" > 0 and request.GET.example_id|add:"0" < 100 and request.GET.tab_id|add:"0" > 0 and request.GET.tab_id|add:"0" < 7 and subtab_semi|add:"0" >= 0 and subtab_semi|add:"0" < 5 %}
+            <script>var gem_path_sep = '{{ gem_path_sep|escapejs }}';</script>
             <script src="{{ STATIC_URL }}ipt/js/examples/{{ request.GET.tab_id|add:"0" }}{{ request.GET.example_id|add:"0"|stringformat:"02d" }}{{subtab_semi|add:"0"|stringformat:"01d" }}.js"></script>
         {% else %}
             <!-- Example not found "ipt/js/examples/{{ request.GET.tab_id|add:"0" }}{{ request.GET.example_id|add:"0"|stringformat:"02d" }}{{ request.GET.subtab_id|add:"0"|stringformat:"01d" }}.js"  -->

--- a/openquakeplatform_ipt/views.py
+++ b/openquakeplatform_ipt/views.py
@@ -716,6 +716,7 @@ def view(request, **kwargs):
             multi_accept[dkey] = dval
 
     render_dict = dict(
+        gem_path_sep=os.path.sep,
         oqp_version_maj=oqp_version.split('.')[0],
         g_gmpe=json.dumps(gmpe),
         rupture_file_html=rupture_file_html,


### PR DESCRIPTION
examples had '/' separator also if server user '\\' , now it is dynamically valorized.
Tests are running here:
  * https://ci.openquake.org/job/zdevel_oq-platform2/1073/
  * https://ci.openquake.org/job/zdevel_oq-platform-standalone/343/