### PR TITLE
update 'Downloads' folder retrieval

### DIFF
--- a/openquakeplatform_ipt/__init__.py
+++ b/openquakeplatform_ipt/__init__.py
@@ -17,4 +17,4 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 header_info = {"title": "IPT"}
-__version__ = '1.18.3'
+__version__ = '1.18.4'

--- a/openquakeplatform_ipt/test/examples_test.py
+++ b/openquakeplatform_ipt/test/examples_test.py
@@ -397,7 +397,6 @@ def gen_timeout_poller(secs, delta):
 def make_function(func_name, exp_path, tab_id, subtab_id, example):
     def generated(self):
         pla = platform_get()
-        homedir = os.path.expanduser('~')
         exp_filename = os.path.join(
             exp_path, "example_%d.%s" % (
                 tab_id * 1000 + example['exa_id'] * 10 + subtab_id,
@@ -405,7 +404,7 @@ def make_function(func_name, exp_path, tab_id, subtab_id, example):
 
         zipfile = ""
         if 'zipfile' in example:
-            zipfile = os.path.join(homedir, 'Downloads', example['zipfile'])
+            zipfile = os.path.join(pla.download_dir, example['zipfile'])
             if os.path.exists(zipfile):
                 os.remove(zipfile)
 


### PR DESCRIPTION
With this PR we align tests that use browser's downloaded files to use the new download folder.
Tests are running here: https://ci.openquake.org/job/zdevel_oq-platform-standalone/344/
