### PR TITLE
Sync requirements with Engine

### DIFF
--- a/requirements-py36-linux64.txt
+++ b/requirements-py36-linux64.txt
@@ -1,6 +1,6 @@
 # GEM Mirror
 # We provide pre-compiled manylinux1 wheels
 
-http://cdn.ftp.openquake.org/wheelhouse/linux/py/Django-2.0.4-py3-none-any.whl
-http://cdn.ftp.openquake.org/wheelhouse/linux/py36/pyproj-1.9.5.1-cp36-cp36m-manylinux1_x86_64.whl
-http://cdn.ftp.openquake.org/wheelhouse/linux/py36/GDAL-2.4.1-cp36-cp36m-manylinux1_x86_64.whl
+https://wheelhouse.openquake.org/v2/linux/py/Django-2.2.7-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/linux/py36/pyproj-1.9.5.1-cp36-cp36m-manylinux1_x86_64.whl
+https://wheelhouse.openquake.org/v2/linux/py36/GDAL-2.4.1.post1-cp36-cp36m-manylinux1_x86_64.whl

--- a/requirements-py36-macos.txt
+++ b/requirements-py36-macos.txt
@@ -1,6 +1,6 @@
 # GEM Mirror
 # We provide pre-compiled manylinux1 wheels
 
-http://cdn.ftp.openquake.org/wheelhouse/linux/py/Django-2.0.4-py3-none-any.whl
-http://cdn.ftp.openquake.org/wheelhouse/macos/py36/pyproj-1.9.5.1-cp36-cp36m-macosx_10_6_intel.whl
-http://cdn.ftp.openquake.org/wheelhouse/macos/py36/GDAL-2.4.1-cp36-cp36m-macosx_10_9_x86_64.whl
+https://wheelhouse.openquake.org/v2/macos/py/Django-2.2.7-py3-none-any.whl
+https://wheelhouse.openquake.org/v2/macos/py36/pyproj-1.9.5.1-cp36-cp36m-macosx_10_6_intel.whl
+https://wheelhouse.openquake.org/v2/macos/py36/GDAL-2.4.1.post1-cp36-cp36m-macosx_10_9_x86_64.whl


### PR DESCRIPTION
Now it uses the proper version of GDAL (post1) and also other deps have been kept in sync with Engine