### PR TITLE
Engine req

### DIFF
--- a/openquakeplatform_ipt/__init__.py
+++ b/openquakeplatform_ipt/__init__.py
@@ -17,4 +17,4 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 header_info = {"title": "IPT"}
-__version__ = '1.19.5'
+__version__ = '1.19.6'

--- a/openquakeplatform_ipt/views.py
+++ b/openquakeplatform_ipt/views.py
@@ -441,12 +441,16 @@ class FileUpload(forms.Form):
     file_upload = forms.FileField(allow_empty_file=True)
 
 
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+
 class FileUploadMulti(forms.Form):
     def __init__(self, *args, **kwargs):
         self.accept = kwargs.pop('accept')
         self.with_subtype = kwargs.pop('with_subtype', False)
         super(FileUploadMulti, self).__init__(*args, **kwargs)
-        self.fields['file_upload'].widget = forms.ClearableFileInput(
+        self.fields['file_upload'].widget = MultipleFileInput(
             attrs={'class': 'hide_file_upload', 'multiple': True,
                    'data-gem-with-subtype': (
                        'true' if self.with_subtype else 'false'),

--- a/requirements-py38-oq-platform-standalone-linux64.txt
+++ b/requirements-py38-oq-platform-standalone-linux64.txt
@@ -1,5 +1,4 @@
 # GEM Mirror
 # We provide pre-compiled manylinux1 wheels
 
-https://wheelhouse.openquake.org/v3/linux/py/Django-3.2.6-py3-none-any.whl
-https://wheelhouse.openquake.org/v3/linux/py38/pyproj-2.5.0-cp38-cp38-manylinux1_x86_64.whl
+openquake.engine >= 3.16


### PR DESCRIPTION
With this PR replace Django and pyproj dependencies with oq-engine dependency.

Implement subclass to manage multiple file upload with new version of Django.

Tests are green here: http://jenkins.gem.lan/job/zdevel_oq-platform-standalone/509/

Close #141 .