### PR TITLE
Classical probabilistic subtab

### DIFF
--- a/openquakeplatform_ipt/templates/ipt/tabs/config_files.html
+++ b/openquakeplatform_ipt/templates/ipt/tabs/config_files.html
@@ -1,7 +1,6 @@
 <div id="cf_subtabs">
   <ul class="nav nav-tabs oqplatform">
     <li><a href="#cf_subtabs-1">Earthquake Scenarios</a></li>
-    <li><a href="#cf_subtabs-2">Classical Probabilistic</a></li>
     <li><a href="#cf_subtabs-3">Stochastic Event-Based</a></li>
     <li><a href="#cf_subtabs-4">Volcano Scenarios</a></li>
   </ul>
@@ -9,10 +8,6 @@
     <div class="tab-pane active in" id="cf_subtabs-1" name="scenario">
       {% include "ipt/tabs/cf/scenario.html" %}
     </div>
-    <div class="tab-pane" id="cf_subtabs-2" name="class-prob">
-      Coming soon ...
-    </div>
-
     <div class="tab-pane" id="cf_subtabs-3" name="event-based">
       {% include "ipt/tabs/cf/event_based.html" %}
     </div>


### PR DESCRIPTION
Deleted 'classical probabilistic' subtab from 'configuration file' tab

The tests are green here: https://jenkins.vpn.openquake.org/job/zdevel_oq-platform-tools/19/